### PR TITLE
fix #7 - referencing initialized state of wrong plugin.

### DIFF
--- a/src/Jellyfin.Plugin.CustomTabs/Inject/addCustomTabs.js
+++ b/src/Jellyfin.Plugin.CustomTabs/Inject/addCustomTabs.js
@@ -12,7 +12,7 @@ if (typeof customTabsPlugin == 'undefined') {
             } );
         },
         mutationHandler: function (mutationRecords) {
-            if (PluginPages.initialized) {
+            if (customTabsPlugin.initialized) {
                 return;
             }
             mutationRecords.forEach ( function (mutation) {


### PR DESCRIPTION
Partial Fix for #7
- `PluginPages` does not exist, but `customTabsPlugin` does.