### PR TITLE
fix #6, #7 - tabs disappearing on section load or not loading at all.

### DIFF
--- a/src/Jellyfin.Plugin.CustomTabs/Inject/addCustomTabs.js
+++ b/src/Jellyfin.Plugin.CustomTabs/Inject/addCustomTabs.js
@@ -12,9 +12,21 @@ if (typeof customTabsPlugin == 'undefined') {
             } );
         },
         mutationHandler: function (mutationRecords) {
-            if (PluginPages.initialized) {
-                return;
+            // get the text of the current page or undefined
+            const currentPage = $('.pageTitle')[0]?.innerHTML
+
+            if (customTabsPlugin.initialized && customTabsPlugin.page === currentPage) {
+              return;
             }
+
+            // If the page didn't match, set our intialized flag to false.
+            customTabsPlugin.initialized = false;
+
+            // We're not on the main page
+            // Config for this could enumerate a list of target pages.
+            if (currentPage !== "") return;
+
+            // Okay, we're back on the main page let's do this thing.
             mutationRecords.forEach ( function (mutation) {
                 console.log (mutation.type);
                 if (mutation.addedNodes && mutation.addedNodes.length > 0) {
@@ -22,6 +34,8 @@ if (typeof customTabsPlugin == 'undefined') {
                     [].some.call(mutation.addedNodes, function (addedNode) {
                         if ($('.emby-tabs-slider').length > 0) {
                             customTabsPlugin.initialized = true;
+                            // store current page title when we succeeded
+                            customTabsPlugin.page = currentPage
                             customTabsPlugin.createCustomTabs();
                         }
                     });


### PR DESCRIPTION
Fix for #6 and #7

Reasoning:
- For one thing, we're tracking the initialized state of an unrelated plugin here.
- For another we need to reset that state when we go to another tab.

Technical Design:
- Use page title to determine if we are on the main page
- If we don't have a title or the title is not empty string we know we aren't on the home page.

Solution:
- fix reference to other plugin
- Store page title element contents on success
- If it changed on mutation observer, set initialized false.
- Early return if current page isn't `""` to prevent tabs showing up on non-home page.