### PR TITLE
Allow custom tabs to load even if additional query strings are appended to the URL

### DIFF
--- a/src/Jellyfin.Plugin.CustomTabs/Inject/addCustomTabs.js
+++ b/src/Jellyfin.Plugin.CustomTabs/Inject/addCustomTabs.js
@@ -16,7 +16,7 @@ if (typeof window.customTabsPlugin == 'undefined') {
         waitForUI: function() {
             // Check if we are on the home page by looking at the URL hash
             const hash = window.location.hash;
-            if (hash !== '' && hash !== '#/home' && hash !== '#/home.html') {
+            if (hash !== '' && hash !== '#/home' && !hash.includes('#/home.html')) {
                 console.debug('CustomTabs: Not on main page, skipping UI check. Hash:', hash);
                 return;
             }


### PR DESCRIPTION
This will allow us to track the tab state using ?tab=N which is already supported by Jellyfin, just not tracked in history. Currently if we do this, the home page custom tabs will not load. The tab content _will_ load, but the actual tab buttons in the header will not.